### PR TITLE
v. 0.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## v. 0.1.2
+ * allow the "cachedir" config field to be ser as `False`, which prevents
+   setting the HF cache directory whatsoever
+
 ## v. 0.1.1
  * fix: package description blurb
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,10 @@
 # ChangeLog
 
 ## v. 0.1.2
- * allow the "cachedir" config field to be ser as `False`, which prevents
+ * allow the "cachedir" config field to be set as `False`, which prevents
    setting the HF cache directory whatsoever
+ * default config uses a multilingual NER model (configured for en, es, fr)
+ * save a tuple (tokenizer, model) in the cache for reuse, not the full pipeline
 
 ## v. 0.1.1
  * fix: package description blurb

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ follows:
    used
 2. Else, if the configuration file for the package contains a `cachedir` field
    inside the `task_config` section, it will be used
-3. Else, a default is chosen: the `var/piisa/hf-cache` subfolder in
+3. If that field contains a `false` value, then **no** specific cache directory
+   will be defined (so the HuggingFace internal default will be used)
+4. Else, a default is chosen: the `var/piisa/hf-cache` subfolder in
    the virtualenv that holds the package
 
 
@@ -58,14 +60,7 @@ defines a plugin entry point. This plugin is automatically picked up by the
 scripts and classes in [pii-extract-base], and thus its functionality is exposed
 to them.
 
-Runtime behaviour is governed by a [configuration file], which sets up which
-models from the HuggingFace Hub will be downloaded and used (note that the
-configuration defines the total set of languages available for detection, but the
-plugin can also be initialized with a _subset_ of those languages).
-
-There are also [examples for other languages].
-
-The task created from the plugin is a standard [PII task] object, using the
+The task created by the plugin is a standard [PII task] object, using the
 `pii_extract.build.task.MultiPiiTask` class definition. It will be called,
 as all PII task objects, with a `DocumentChunk` object containing the data to
 analyze. The chunk **must** contain language specification in its metadata, so
@@ -74,8 +69,25 @@ built with *only one* language; in that case if the chunk does not contain
 a language specification, it will use that single language).
 
 
-## Auxiliary scripts
+## Configuration
 
+Runtime behaviour is governed by a [PIISA configuration file], which sets up which
+models from the HuggingFace Hub will be downloaded and used (note that the
+configuration defines the total set of languages available for detection, but
+it is also possible to initialize the plugin with a _subset_ of the configuration
+languages).
+
+The [default configuration file] defines detection for `Person` and `Location`
+PII instances for English, Spanish and French, using the [WikiNEuRal] multilingual
+NER model available in the Hugging Face Hub.
+
+However, a configuration file can
+also define a different model per language, and a different set of PII to detect
+for each model (and also different aggregation strategies to merge the model
+output). There is [another example available].
+
+
+## Auxiliary scripts
 
 ### Information
 
@@ -125,12 +137,10 @@ The provided [Makefile] can be used to process the package:
 [pii-data]: https://github.com/piisa/pii-data
 [pii-extract-base]: https://github.com/piisa/pii-extract-base
 [pii task descriptors]: https://github.com/piisa/pii-extract-base/tree/main/doc/task-descriptor.md
-[Presidio]: https://microsoft.github.io/presidio/
-[presidio-analyzer]: https://microsoft.github.io/presidio/analyzer/
-[customizing NLP models]: https://microsoft.github.io/presidio/analyzer/customizing_nlp_models/
 [Makefile]: Makefile
 [pytest]: https://docs.pytest.org
-[default file]: src/pii_extract_plg_presidio/resources/plugin-config.json
-[configuration file]: doc/configuration.md
-[examples for other languages]: doc/examples.md
+[default configuration file]: src/pii_extract_plg_transformers/resources/plugin-config.json
+[PIISA configuration file]: doc/configuration.md
+[another example available]: doc/examples.md
 [PII task]: https://github.com/piisa/pii-extract-base/blob/main/doc/task-implementation.md
+[WikiNEuRal]: https://huggingface.co/Babelscape/wikineural-multilingual-ner

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -1,9 +1,9 @@
 # Examples
 
-The [default configuration] defines models for English and Spanish. There is
-also another [example configuration](example6.json) available that extends it
-to add French, German, Portuguese and Italian. Its behaviour can be tested using
-the `detect` script like this:
+The [default configuration] defines a multilingual model, used for English,
+Spanish and French. There is also another [example configuration](example6.json)
+available that uses models for English, Spanish, French, German, Portuguese and
+Italian. Its behaviour can be tested using the `detect` script like this:
 
 
 * English:
@@ -31,7 +31,7 @@ the `detect` script like this:
         pii-extract-transformers-detect --config example6.json --lang pt --input-data "Ciao. Mi chiamo Iñigo Montoya. Tu hai ucciso mio padre a Toledo"
 
 
-Note that the models defined in the configuration are only examples; the
+Note that the models defined in this configuration are only examples; the
 Hugging Face Hub contains many models for NER Token Classification, and some
 of them might be more appropriate than others for PII detection tasks.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 transformers >= 4.30
 
 pii-data >= 0.4.0, <1.0.0
-pii-extract-base >= 0.5.0, <1.0.0
+pii-extract-base >= 0.6.1, <1.0.0

--- a/src/pii_extract_plg_transformers/__init__.py
+++ b/src/pii_extract_plg_transformers/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.1"
+VERSION = "0.1.2"

--- a/src/pii_extract_plg_transformers/resources/plugin-config.json
+++ b/src/pii_extract_plg_transformers/resources/plugin-config.json
@@ -4,21 +4,21 @@
     "reuse_engine": true,
     "aggregation": "max",
     "models": [
-      {"lang_code": "en", "model": "dslim/bert-base-NER"},
-      {"lang_code": "es", "model": "MMG/xlm-roberta-large-ner-spanish",
-       "aggregation": "simple"}
+      {"lang_code": "en", "model": "Babelscape/wikineural-multilingual-ner"},
+      {"lang_code": "es", "model": "Babelscape/wikineural-multilingual-ner"},
+      {"lang_code": "fr", "model": "Babelscape/wikineural-multilingual-ner"}
     ]
   },
   "pii_list": [
     {
       "type": "PERSON",
-      "lang": ["en", "es"],
+      "lang": ["en", "es", "fr"],
       "method": "model",
       "extra": {"map": "PER"}
     },
     {
       "type": "LOCATION",
-      "lang": ["en", "es"],
+      "lang": ["en", "es", "fr"],
       "method": "model",
       "extra": {"map": "LOC"}
     }

--- a/src/pii_extract_plg_transformers/task/pipeline.py
+++ b/src/pii_extract_plg_transformers/task/pipeline.py
@@ -92,12 +92,16 @@ def create_pipelines(config: Dict, languages: Iterable[str] = None,
 
         # Look for it in cache
         if reuse:
-            key = f"{tkname}/{mdname}/{agg}"
+            # Build the cache key
+            key = f"{tkname}/{mdname}"
             if par:
                 key += '/' + '-'.join(f"{k}={par[k]}" for k in sorted(par))
-            engine = ENGINE_CACHE.get(key)
-            if engine:
-                pdict[lang] = engine
+
+            # Try to find it in cache
+            model = ENGINE_CACHE.get(key)
+            if model:
+                pdict[lang] = pipeline("ner", tokenizer=model[0], model=model[1],
+                                       aggregation_strategy=agg)
                 if logger:
                     logger(".... Reusing Transformers pipeline for %s: %s", lang, mdname)
                 continue
@@ -110,6 +114,6 @@ def create_pipelines(config: Dict, languages: Iterable[str] = None,
 
         # Save to cache
         if reuse:
-            ENGINE_CACHE[key] = pdict[lang]
+            ENGINE_CACHE[key] = tokenizer, model
 
     return pdict

--- a/src/pii_extract_plg_transformers/task/task.py
+++ b/src/pii_extract_plg_transformers/task/task.py
@@ -82,7 +82,9 @@ class TransformersTask(BaseMultiPiiTask):
                   len(pii), self.lang)
 
         # Define cache directory (_before_ importing the pipeline module)
-        hf_cachedir(cfg.get("cachedir"))
+        cachedir = cfg.get("cachedir")
+        if cachedir is not False:
+            hf_cachedir(cachedir)
 
         # Set up the Transformers pipeline engine
         try:

--- a/src/pii_extract_plg_transformers/task/utils.py
+++ b/src/pii_extract_plg_transformers/task/utils.py
@@ -9,7 +9,7 @@ from importlib.metadata import version
 
 from typing import Dict, Set
 
-from pii_data.helper.exception import ConfigException
+from pii_data.helper.exception import ConfigException, FileException
 
 
 ENV_HF_CACHE = "HUGGINGFACE_HUB_CACHE"
@@ -29,8 +29,11 @@ def hf_cachedir(cachedir: str = None):
     else:
         cachedir = Path(sys.prefix) / "var" / "piisa" / "hf-cache"
     # Create directory if neded
-    if not cachedir.is_dir():
-        cachedir.mkdir(parents=True)
+    try:
+        if not cachedir.is_dir():
+            cachedir.mkdir(parents=True)
+    except Exception as e:
+        raise FileException("cannot create HF cachedir '{}': {}", cachedir, e) from e
     # Push it to the environment
     environ[ENV_HF_CACHE] = str(cachedir)
     #print("CACHEDIR", str(cachedir))

--- a/test/taux/monkey_patch.py
+++ b/test/taux/monkey_patch.py
@@ -2,12 +2,15 @@
 Some utils to monkey patch objects in the plugin
 """
 
+from os import environ
+
 from unittest.mock import Mock
 
 from typing import List, Dict
 
 from pii_extract.gather.collection.sources.defs import PII_EXTRACT_PLUGIN_ID
 from pii_extract_plg_transformers.plugin_loader import PiiExtractPluginLoader
+from pii_extract_plg_transformers.task.utils import ENV_HF_CACHE
 
 import pii_extract.gather.collection.sources.plugin as mod1
 import pii_extract_plg_transformers.task.pipeline as mod_pl
@@ -57,3 +60,12 @@ def patch_transformer_pipeline(monkeypatch, results: Dict,
     monkeypatch.setattr(mod_pl, 'ENGINE_CACHE', {})
 
     return pipeline_creator
+
+
+def patch_env(monkeypatch):
+    """
+    Monkey patch the environment variables
+    """
+    m = environ.get(ENV_HF_CACHE)
+    if m:
+        monkeypatch.delenv(ENV_HF_CACHE)

--- a/test/unit/test_B_plugin_collector.py
+++ b/test/unit/test_B_plugin_collector.py
@@ -50,11 +50,11 @@ def test30_task_pii(monkeypatch):
 
     tasks = _get_tasks()
     pii = tasks[0]["piid"]
-    assert len(pii) == 4
+    assert len(pii) == 6
 
     got_transformers_ent = [(p["extra"]["map"], p["lang"]) for p in pii]
     exp_transformers_ent = [
-        ("PER", "en"), ("PER", "es"),
-        ("LOC", "en"), ("LOC", "es")
+        ("PER", "en"), ("PER", "es"), ("PER", "fr"),
+        ("LOC", "en"), ("LOC", "es"), ("LOC", "fr")
     ]
     assert exp_transformers_ent == got_transformers_ent

--- a/test/unit/test_C_detector.py
+++ b/test/unit/test_C_detector.py
@@ -7,7 +7,7 @@ import pytest
 from pii_data.helper.exception import ConfigException
 from pii_extract.gather.collection import get_task_collection
 
-from taux.monkey_patch import patch_entry_points, patch_transformer_pipeline
+from taux.monkey_patch import patch_entry_points, patch_transformer_pipeline, patch_env
 
 # ---------------------------------------------------------------------------
 
@@ -18,6 +18,7 @@ def test10_tasklist(monkeypatch):
     """
     patch_entry_points(monkeypatch)
     patch_transformer_pipeline(monkeypatch, {}, model_labels=["PER", "LOC"])
+    patch_env(monkeypatch)
 
     piic = get_task_collection(debug=False)
     tasks = piic.build_tasks()
@@ -32,6 +33,7 @@ def test11_tasklist_err(monkeypatch):
     """
     patch_entry_points(monkeypatch)
     patch_transformer_pipeline(monkeypatch, {})
+    patch_env(monkeypatch)
 
     piic = get_task_collection(debug=False)
     tasks = piic.build_tasks()
@@ -45,6 +47,7 @@ def test20_tasklist_lang(monkeypatch):
     """
     patch_entry_points(monkeypatch)
     patch_transformer_pipeline(monkeypatch, {}, model_labels=["PER", "LOC"])
+    patch_env(monkeypatch)
 
     piic = get_task_collection(debug=False)
     tasks = piic.build_tasks('en')
@@ -58,6 +61,8 @@ def test30_engine_cache(monkeypatch):
     Check engine object reuse
     """
     patch_entry_points(monkeypatch)
+    patch_env(monkeypatch)
+
     mck = patch_transformer_pipeline(monkeypatch, {}, model_labels=["PER", "LOC"])
 
     piic = get_task_collection(debug=True)

--- a/test/unit/test_C_detector.py
+++ b/test/unit/test_C_detector.py
@@ -24,7 +24,7 @@ def test10_tasklist(monkeypatch):
     tasks = piic.build_tasks()
     tasks = list(tasks)
     assert len(tasks) == 1
-    assert str(tasks[0]) == "<Transformers wrapper #4>"
+    assert str(tasks[0]) == "<Transformers wrapper #6>"
 
 
 def test11_tasklist_err(monkeypatch):

--- a/test/unit/test_D_process.py
+++ b/test/unit/test_D_process.py
@@ -111,7 +111,7 @@ def test30_error_lang(monkeypatch):
     patch_env(monkeypatch)
 
     # Gather tasks and build them. Use two languages, to preclude definition
-    # of a default language in the Presidio task
+    # of a default language in the task
     piic = get_task_collection()
     tasks = piic.build_tasks(["en", "es"])
     tasks = list(tasks)

--- a/test/unit/test_D_process.py
+++ b/test/unit/test_D_process.py
@@ -7,7 +7,7 @@ import pytest
 from pii_data.helper.exception import ProcException
 from pii_extract.gather.collection import get_task_collection
 
-from taux.monkey_patch import patch_entry_points, patch_transformer_pipeline
+from taux.monkey_patch import patch_entry_points, patch_transformer_pipeline, patch_env
 from taux.taskproc import process_tasks
 
 
@@ -43,12 +43,13 @@ def test20_detect(monkeypatch):
     """
     Check detection
     """
-    # Patch the plugin entry point so that only the presidio plugin is detected
+    # Patch the plugin entry point so that only this plugin is detected
     patch_entry_points(monkeypatch)
-
-    # Patch the presidio analyzer function so that we don't actually call Presidio
+    # Patch the pipeline creation function so that we use a mock
     results = TESTCASES[0][1]
     patch_transformer_pipeline(monkeypatch, results, ["LOC", "PER"])
+    # Patch environment
+    patch_env(monkeypatch)
 
     # Gather tasks and build them
     piic = get_task_collection()
@@ -71,12 +72,13 @@ def test21_detect_default_lang(monkeypatch):
     """
     Check detection, with a default language
     """
-    # Patch the plugin entry point so that only the presidio plugin is detected
+    # Patch the plugin entry point so that only this plugin is detected
     patch_entry_points(monkeypatch)
-
-    # Patch the presidio analyzer function so that we don't actually call Presidio
+    # Patch the pipeline creation function so that we use a mock
     results = TESTCASES[0][1]
     patch_transformer_pipeline(monkeypatch, results, ["LOC", "PER"])
+    # Patch environment
+    patch_env(monkeypatch)
 
     # Gather tasks and build them
     piic = get_task_collection()
@@ -100,12 +102,13 @@ def test30_error_lang(monkeypatch):
     """
     Check error generation due to language not specified
     """
-    # Patch the plugin entry point so that only the presidio plugin is detected
+    # Patch the plugin entry point so that only this plugin is detected
     patch_entry_points(monkeypatch)
-
-    # Patch the presidio analyzer function so that we don't actually call Presidio
+    # Patch the pipeline creation function so that we use a mock
     results = TESTCASES[0][1]
     patch_transformer_pipeline(monkeypatch, results, ["LOC", "PER"])
+    # Patch environment
+    patch_env(monkeypatch)
 
     # Gather tasks and build them. Use two languages, to preclude definition
     # of a default language in the Presidio task


### PR DESCRIPTION
 * allow the "cachedir" config field to be set as `False`, which prevents setting the HF cache directory whatsoever
 * default config uses a multilingual NER model (configured for en, es, fr)
 * save a tuple (tokenizer, model) in the cache for reuse, not the full pipeline